### PR TITLE
add convenience API for initializing HTML, RSS, and SVG from raw UTF8 data

### DIFF
--- a/Sources/DOM/DOM.Node.swift
+++ b/Sources/DOM/DOM.Node.swift
@@ -18,6 +18,11 @@ extension DOM
         {
             self = .value(.init(escaped: string))
         }
+        @inlinable public 
+        init<UTF8>(escaped utf8:UTF8) where UTF8:Collection, UTF8.Element == UInt8
+        {
+            self = .value(.init(escaped: utf8))
+        }
     }
 }
 extension DOM.Node 

--- a/Sources/HTML/HTML.Element.swift
+++ b/Sources/HTML/HTML.Element.swift
@@ -27,6 +27,11 @@ enum HTML
             self.init(node: .init(escaped: string))
         }
         @inlinable public 
+        init<UTF8>(escaped utf8:UTF8) where UTF8:Collection, UTF8.Element == UInt8
+        {
+            self.init(node: .init(escaped: utf8))
+        }
+        @inlinable public 
         init(anchor:Anchor) 
         {
             self.init(node: .value(.anchor(anchor)))

--- a/Sources/RSS/RSS.Element.swift
+++ b/Sources/RSS/RSS.Element.swift
@@ -34,6 +34,11 @@ enum RSS
             self.init(node: .init(escaped: string))
         }
         @inlinable public 
+        init<UTF8>(escaped utf8:UTF8) where UTF8:Collection, UTF8.Element == UInt8
+        {
+            self.init(node: .init(escaped: utf8))
+        }
+        @inlinable public 
         init(anchor:Anchor) 
         {
             self.init(node: .value(.anchor(anchor)))

--- a/Sources/SVG/SVG.Element.swift
+++ b/Sources/SVG/SVG.Element.swift
@@ -34,6 +34,11 @@ enum SVG
             self.init(node: .init(escaped: string))
         }
         @inlinable public 
+        init<UTF8>(escaped utf8:UTF8) where UTF8:Collection, UTF8.Element == UInt8
+        {
+            self.init(node: .init(escaped: utf8))
+        }
+        @inlinable public 
         init(anchor:Anchor) 
         {
             self.init(node: .value(.anchor(anchor)))


### PR DESCRIPTION
this cannot be factored into a protocol, for a dumb reason (`DOM` is a single-type module, and adding a protocol to it would make it impossible to use qualified references.)